### PR TITLE
Export RuleCondition

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -60,6 +60,7 @@ export * from './model/sensors/GeoFence';
 export * from './model/rules/Rule';
 export * from './model/rules/conditions/SensorCondition';
 export * from './model/rules/conditions/GroupCondition';
+export * from './model/rules/conditions/RuleCondition';
 export * from './model/actions/LightStateAction';
 export * from './model/actions/SensorStateAction';
 export * from './model/actions/GroupStateAction';


### PR DESCRIPTION
Exports the RuleCondition module.

Example usage:
```typescript
  const timeCondition = new model.RuleCondition({
    address: "/config/localtime",
    operator: model.ruleConditionOperators.notIn,
    value: "T23:00:00/T08:00:00",
  });
```