### PR TITLE
Adding new value for Entertainment

### DIFF
--- a/src/model/groups/Entertainment.ts
+++ b/src/model/groups/Entertainment.ts
@@ -4,7 +4,7 @@ import { BooleanType, ChoiceType, ListType, ObjectType, StringType } from '../..
 const ATTRIBUTES = [
   new StringType({name: 'type', defaultValue: 'Entertainment'}),
   // iOS Hue application is defaulting the types to TV currently, also only TV and Other seem to work out of all the classes
-  new ChoiceType({name: 'class', defaultValue: 'TV', validValues: ['TV', 'Other']}),
+  new ChoiceType({name: 'class', defaultValue: 'TV', validValues: ['TV', 'Free', 'Other']}),
   new ObjectType({
     name: 'stream',
     types: [
@@ -53,7 +53,7 @@ export class Entertainment extends Group {
     return this.getAttributeValue('class');
   }
 
-  get stream(): Stream  {
+  get stream(): Stream {
     return this.getAttributeValue('stream');
   }
 

--- a/src/model/groups/Group.ts
+++ b/src/model/groups/Group.ts
@@ -44,6 +44,7 @@ const ROOM_CLASSES = [
   'Porch',
   'Barbecue',
   'Pool',
+  'Free',
 ];
 
 


### PR DESCRIPTION
When creating a new Entertainment group for music, in the Hue app on iOS, the class value is set to "Free", which was not a valid value.